### PR TITLE
Fix logging file size issue

### DIFF
--- a/02_classify_mutations/run_mutation_classification.py
+++ b/02_classify_mutations/run_mutation_classification.py
@@ -130,11 +130,6 @@ if __name__ == '__main__':
         'shuffle_labels',
         'skip_reason'
     ]
-    if io_args.log_file.exists() and io_args.log_file.is_file():
-        log_df = pd.read_csv(io_args.log_file, sep='\t')
-    else:
-        log_df = pd.DataFrame(columns=log_columns)
-        log_df.to_csv(io_args.log_file, sep='\t')
 
     tcga_data = TCGADataModel(seed=model_options.seed,
                               subset_mad_genes=model_options.subset_mad_genes,

--- a/02_classify_mutations/run_mutation_compressed.py
+++ b/02_classify_mutations/run_mutation_compressed.py
@@ -130,11 +130,6 @@ if __name__ == '__main__':
         'shuffle_labels',
         'skip_reason'
     ]
-    if io_args.log_file.exists() and io_args.log_file.is_file():
-        log_df = pd.read_csv(io_args.log_file, sep='\t')
-    else:
-        log_df = pd.DataFrame(columns=log_columns)
-        log_df.to_csv(io_args.log_file, sep='\t')
 
     tcga_data = TCGADataModel(seed=model_options.seed,
                               training_data=model_options.training_data,
@@ -162,7 +157,7 @@ if __name__ == '__main__':
                         file=sys.stdout)
 
         for gene_idx, gene_series in progress:
-            mutation_log_df = None
+            log_df = None
             gene = gene_series.gene
             classification = gene_series.classification
             progress.set_description('gene: {}'.format(gene))
@@ -182,22 +177,22 @@ if __name__ == '__main__':
                 if io_args.verbose:
                     print('Skipping because results file exists already: gene {}'.format(
                         gene), file=sys.stderr)
-                mutation_log_df = fu.generate_log_df(
+                log_df = fu.generate_log_df(
                     log_columns,
                     [gene, model_options.training_data, shuffle_labels, 'file_exists']
                 )
-                fu.write_log_file(mutation_log_df, io_args.log_file)
+                fu.write_log_file(log_df, io_args.log_file)
                 continue
             except KeyError:
                 # this might happen if the given gene isn't in the mutation data
                 # (or has a different alias, TODO we could check for this later)
                 print('Gene {} not found in mutation data, skipping'.format(gene),
                       file=sys.stderr)
-                mutation_log_df = fu.generate_log_df(
+                log_df = fu.generate_log_df(
                     log_columns,
                     [gene, model_options.training_data, shuffle_labels, 'gene_not_found']
                 )
-                fu.write_log_file(mutation_log_df, io_args.log_file)
+                fu.write_log_file(log_df, io_args.log_file)
                 continue
 
             try:
@@ -224,7 +219,7 @@ if __name__ == '__main__':
                 if io_args.verbose:
                     print('Skipping due to no train samples: gene {}'.format(
                         gene), file=sys.stderr)
-                mutation_log_df = fu.generate_log_df(
+                log_df = fu.generate_log_df(
                     log_columns,
                     [gene, model_options.training_data, shuffle_labels, 'no_train_samples']
                 )
@@ -232,11 +227,11 @@ if __name__ == '__main__':
                 if io_args.verbose:
                     print('Skipping due to one holdout class: gene {}'.format(
                         gene), file=sys.stderr)
-                mutation_log_df = fu.generate_log_df(
+                log_df = fu.generate_log_df(
                     log_columns,
                     [gene, model_options.training_data, shuffle_labels, 'one_class']
                 )
 
-            if mutation_log_df is not None:
-                fu.write_log_file(mutation_log_df, io_args.log_file)
+            if log_df is not None:
+                fu.write_log_file(log_df, io_args.log_file)
 

--- a/03_classify_cancer_type/run_cancer_type_classification.py
+++ b/03_classify_cancer_type/run_cancer_type_classification.py
@@ -125,11 +125,6 @@ if __name__ == '__main__':
         'shuffle_labels',
         'skip_reason'
     ]
-    if io_args.log_file.exists() and io_args.log_file.is_file():
-        log_df = pd.read_csv(io_args.log_file, sep='\t')
-    else:
-        log_df = pd.DataFrame(columns=log_columns)
-        log_df.to_csv(io_args.log_file, sep='\t')
 
     # load data matrix for the specified data type
     tcga_data = TCGADataModel(seed=model_options.seed,
@@ -153,7 +148,7 @@ if __name__ == '__main__':
                         file=sys.stdout)
 
         for cancer_type in progress:
-            cancer_type_log_df = None
+            log_df = None
             progress.set_description('cancer type: {}'.format(cancer_type))
 
             try:
@@ -170,11 +165,11 @@ if __name__ == '__main__':
                 if io_args.verbose:
                     print('Skipping because results file exists already: '
                           'cancer type {}'.format(cancer_type), file=sys.stderr)
-                cancer_type_log_df = fu.generate_log_df(
+                log_df = fu.generate_log_df(
                     log_columns,
                     [cancer_type, model_options.training_data, shuffle_labels, 'file_exists']
                 )
-                fu.write_log_file(cancer_type_log_df, io_args.log_file)
+                fu.write_log_file(log_df, io_args.log_file)
                 continue
 
             try:
@@ -203,7 +198,7 @@ if __name__ == '__main__':
                 if io_args.verbose:
                     print('Skipping due to no test samples: cancer type '
                           '{}'.format(cancer_type), file=sys.stderr)
-                cancer_type_log_df = fu.generate_log_df(
+                log_df = fu.generate_log_df(
                     log_columns,
                     [cancer_type, model_options.training_data, shuffle_labels, 'no_test_samples']
                 )
@@ -211,11 +206,11 @@ if __name__ == '__main__':
                 if io_args.verbose:
                     print('Skipping due to one holdout class: cancer type '
                           '{}'.format(cancer_type), file=sys.stderr)
-                cancer_type_log_df = fu.generate_log_df(
+                log_df = fu.generate_log_df(
                     log_columns,
                     [cancer_type, model_options.training_data, shuffle_labels, 'one_class']
                 )
 
-            if cancer_type_log_df is not None:
-                fu.write_log_file(cancer_type_log_df, io_args.log_file)
+            if log_df is not None:
+                fu.write_log_file(log_df, io_args.log_file)
 

--- a/04_predict_controls/run_msi_prediction.py
+++ b/04_predict_controls/run_msi_prediction.py
@@ -138,11 +138,7 @@ if __name__ == '__main__':
         'shuffle_labels',
         'skip_reason'
     ]
-    if io_args.log_file.exists() and io_args.log_file.is_file():
-        log_df = pd.read_csv(io_args.log_file, sep='\t')
-    else:
-        log_df = pd.DataFrame(columns=log_columns)
-        log_df.to_csv(io_args.log_file, sep='\t')
+    log_df = None
 
     tcga_data = TCGADataModel(seed=model_options.seed,
                               subset_mad_genes=model_options.subset_mad_genes,

--- a/04_predict_controls/run_purity_prediction.py
+++ b/04_predict_controls/run_purity_prediction.py
@@ -134,11 +134,7 @@ if __name__ == '__main__':
         'shuffle_labels',
         'skip_reason'
     ]
-    if io_args.log_file.exists() and io_args.log_file.is_file():
-        purity_log_df = pd.read_csv(io_args.log_file, sep='\t')
-    else:
-        purity_log_df = pd.DataFrame(columns=log_columns)
-        purity_log_df.to_csv(io_args.log_file, sep='\t')
+    log_df = None
 
     tcga_data = TCGADataModel(seed=model_options.seed,
                               subset_mad_genes=model_options.subset_mad_genes,
@@ -169,11 +165,11 @@ if __name__ == '__main__':
             # run (i.e. the results file already exists)
             if io_args.verbose:
                 print('Skipping because results file exists already', file=sys.stderr)
-            purity_log_df = fu.generate_log_df(
+            log_df = fu.generate_log_df(
                 log_columns,
                 [model_options.training_data, shuffle_labels, 'file_exists']
             )
-            fu.write_log_file(purity_log_df, io_args.log_file)
+            fu.write_log_file(log_df, io_args.log_file)
             continue
 
         tcga_data.process_purity_data(experiment_dir,
@@ -205,18 +201,18 @@ if __name__ == '__main__':
         except NoTrainSamplesError:
             if io_args.verbose:
                 print('Skipping due to no train samples', file=sys.stderr)
-            purity_log_df = fu.generate_log_df(
+            log_df = fu.generate_log_df(
                 log_columns,
                 [model_options.training_data, shuffle_labels, 'no_train_samples']
             )
         except OneClassError:
             if io_args.verbose:
                 print('Skipping due to one holdout class', file=sys.stderr)
-            purity_log_df = fu.generate_log_df(
+            log_df = fu.generate_log_df(
                 log_columns,
                 [model_options.training_data, shuffle_labels, 'one_class']
             )
 
-        if purity_log_df is not None:
-            fu.write_log_file(purity_log_df, io_args.log_file)
+        if log_df is not None:
+            fu.write_log_file(log_df, io_args.log_file)
 

--- a/05_classify_mutations_multimodal/run_mutation_classification.py
+++ b/05_classify_mutations_multimodal/run_mutation_classification.py
@@ -156,11 +156,6 @@ if __name__ == '__main__':
         'shuffle_labels',
         'skip_reason'
     ]
-    if io_args.log_file.exists() and io_args.log_file.is_file():
-        log_df = pd.read_csv(io_args.log_file, sep='\t')
-    else:
-        log_df = pd.DataFrame(columns=log_columns)
-        log_df.to_csv(io_args.log_file, sep='\t')
 
     tcga_data = TCGADataModel(seed=model_options.seed,
                               subset_mad_genes=model_options.subset_mad_genes,

--- a/06_predict_survival/run_survival_prediction.py
+++ b/06_predict_survival/run_survival_prediction.py
@@ -144,7 +144,6 @@ if __name__ == '__main__':
         'shuffle_labels',
         'skip_reason'
     ]
-    log_df = pd.DataFrame(columns=log_columns)
 
     tcga_data = TCGADataModel(seed=model_options.seed,
                               subset_mad_genes=model_options.subset_mad_genes,
@@ -173,6 +172,7 @@ if __name__ == '__main__':
                         file=sys.stdout)
 
         for cancer_type in progress:
+            log_df = None
 
             try:
                 check_file = fu.check_output_file(experiment_dir,

--- a/06_predict_survival/run_survival_prediction.py
+++ b/06_predict_survival/run_survival_prediction.py
@@ -43,7 +43,7 @@ def process_args():
                          'combining cancer types, default is all individual TCGA '
                          'cancer types + pan-cancer model')
     io.add_argument('--log_file', default=None,
-                    help='name of file to log skipped genes to')
+                    help='name of file to log skipped cancer types to')
     io.add_argument('--output_survival_fn', action='store_true')
     io.add_argument('--results_dir', default=cfg.results_dirs['survival'],
                     help='where to write results to')
@@ -144,11 +144,7 @@ if __name__ == '__main__':
         'shuffle_labels',
         'skip_reason'
     ]
-    if io_args.log_file.exists() and io_args.log_file.is_file():
-        log_df = pd.read_csv(io_args.log_file, sep='\t')
-    else:
-        log_df = pd.DataFrame(columns=log_columns)
-        log_df.to_csv(io_args.log_file, sep='\t')
+    log_df = pd.DataFrame(columns=log_columns)
 
     tcga_data = TCGADataModel(seed=model_options.seed,
                               subset_mad_genes=model_options.subset_mad_genes,
@@ -263,7 +259,6 @@ if __name__ == '__main__':
                     log_columns,
                     [cancer_type, model_options.training_data, shuffle_labels, 'no_comparable_pairs']
                 )
-
 
             if log_df is not None:
                 fu.write_log_file(log_df, io_args.log_file)

--- a/mpmp/utilities/file_utilities.py
+++ b/mpmp/utilities/file_utilities.py
@@ -227,5 +227,10 @@ def generate_log_df(log_columns, log_values):
 
 def write_log_file(log_df, log_file):
     """Append log output to log file."""
-    log_df.to_csv(log_file, mode='a', sep='\t', index=False, header=False)
+    if log_file.is_file():
+        # if log file already exists append to it, without the column headers
+        log_df.to_csv(log_file, mode='a', sep='\t', index=False, header=False)
+    else:
+        # if log file doesn't exist create it, with column headers
+        log_df.to_csv(log_file, sep='\t', index=False)
 


### PR DESCRIPTION
I've been having an issue where for some of my long-running scripts, I end up with a log file that's 50-100 GB in size. This causes some storage issues, as you may imagine.

These changes should fix that. In short, the problem was that every time I run my scripts, the existing log file was being duplicated - with the fix I'm just appending to the existing file, resulting in much more reasonably sized (and useful) logging output.